### PR TITLE
Restore the Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "daily"
-          time: "05:00"
-      labels:
-          - "Dependencies 📦"
-          - "PHP 🐘"
-      versioning-strategy: "increase"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    labels:
+      - "Dependabot 🤖"
+    versioning-strategy: "increase"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
This effectively reverts #90. Restoring the limit because of the useless amount of CI run this causes if Dependabot has several PR's open and it has to rebase due to another PR getting merged.