### PR TITLE
Run all tests in a fiber

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+
+[*.neon]
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -17,13 +17,67 @@ composer require wyrihaximus/async-test-utilities
 
 # Usage
 
-Any test file can extend `WyriHaximus\AsyncTestUtilities\TestCase` and it comes with some goodies such as random namespaces and random directories to use for file storage related tests.
+Any test file can extend `WyriHaximus\AsyncTestUtilities\TestCase` and it comes with some goodies such as random
+namespaces and random directories to use for file storage related tests.
+
+Since all tests are executed inside a fiber, there is a default timeout of `30` seconds. To lower or raise that timeout
+this package comes with a `TimeOut` attribute. It can be set on the class and method level. When set on both the method level it takes priority over the class level.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\Tests\AsyncTestUtilities;
+
+use React\EventLoop\Loop;
+use WyriHaximus\AsyncTestUtilities\AsyncTestCase;
+use WyriHaximus\AsyncTestUtilities\TimeOut;
+
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\resolve;
+use function React\Promise\Timer\sleep;
+use function time;
+
+#[TimeOut(0.3)]
+final class AsyncTestCaseTest extends AsyncTestCase
+{
+    #[TimeOut(1)]
+    public function testAllTestsAreRanInAFiber(): void
+    {
+        self::expectOutputString('ab');
+
+        Loop::futureTick(async(static function (): void {
+            echo 'a';
+        }));
+
+        await(sleep(1));
+
+        echo 'b';
+    }
+
+    public function testExpectCallableExactly(): void
+    {
+        $callable = $this->expectCallableExactly(3);
+
+        Loop::futureTick($callable);
+        Loop::futureTick($callable);
+        Loop::futureTick($callable);
+    }
+
+    public function testExpectCallableOnce(): void
+    {
+        Loop::futureTick($this->expectCallableOnce());
+    }
+}
+```
 
 # License
 
 The MIT License (MIT)
 
-Copyright (c) 2021 Cees-Jan Kiewiet
+Copyright (c) 2023 Cees-Jan Kiewiet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "wyrihaximus/test-utilities": "^5.5.0 || ^6"
   },
   "require-dev": {
+    "react/promise-timer": "^1.9",
     "wyrihaximus/iterator-or-array-to-array": "^1.2"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa3a4833fd7b285a1940f61f7298dd96",
+    "content-hash": "da9ff199bdf5a13c563a2267ce2169b9",
     "packages": [
         {
             "name": "amphp/amp",
@@ -10232,6 +10232,89 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "react/promise-timer",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise-timer.git",
+                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
+                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.0 || ^2.7.0 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
+            "homepage": "https://github.com/reactphp/promise-timer",
+            "keywords": [
+                "async",
+                "event-loop",
+                "promise",
+                "reactphp",
+                "timeout",
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise-timer/issues",
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/WyriHaximus",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-06-13T13:41:03+00:00"
+        },
         {
             "name": "wyrihaximus/iterator-or-array-to-array",
             "version": "1.2.0",

--- a/etc/qa/phpstan.neon
+++ b/etc/qa/phpstan.neon
@@ -1,8 +1,12 @@
 parameters:
-	excludes_analyse:
+	excludePaths:
 		- tests/bootstrap.php
 	ignoreErrors:
+		- '#Parameter \#1 \$name of method PHPUnit\\Framework\\TestCase::setName\(\) expects string, string\|null given.#'
+		- '#Trying to invoke array\{\$this\(WyriHaximus\\AsyncTestUtilities\\AsyncTestCase\), string\|null\} but it might not be a callable.#'
 		- '#Method WyriHaximus\\AsyncTestUtilities\\CallableStub::__invoke\(\) is not final, but since the containing class is abstract, it should be.#'
+		- '#Parameter \#1 \$name of method ReflectionClass\<\$this\(WyriHaximus\\AsyncTestUtilities\\AsyncTestCase\)\>::getMethod\(\) expects string, string\|null given.#'
+		- '#Call to an undefined method React\\Promise\\PromiseInterface\<mixed\>::always\(\).#'
 		- '#Call to deprecated method await\(\) of class WyriHaximus\\AsyncTestUtilities\\AsyncTestCase#'
 		- '#Call to deprecated method awaitAll\(\) of class WyriHaximus\\AsyncTestUtilities\\AsyncTestCase#'
 		- '#Call to deprecated method awaitAny\(\) of class WyriHaximus\\AsyncTestUtilities\\AsyncTestCase#'

--- a/src/TimeOut.php
+++ b/src/TimeOut.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\AsyncTestUtilities;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+final readonly class TimeOut
+{
+    public function __construct(
+        public int|float $timeout,
+    ) {
+    }
+}

--- a/tests/AsyncTestCaseTest.php
+++ b/tests/AsyncTestCaseTest.php
@@ -6,12 +6,31 @@ namespace WyriHaximus\Tests\AsyncTestUtilities;
 
 use React\EventLoop\Loop;
 use WyriHaximus\AsyncTestUtilities\AsyncTestCase;
+use WyriHaximus\AsyncTestUtilities\TimeOut;
 
+use function React\Async\async;
+use function React\Async\await;
 use function React\Promise\resolve;
+use function React\Promise\Timer\sleep;
 use function time;
 
+#[TimeOut(1)]
 final class AsyncTestCaseTest extends AsyncTestCase
 {
+    #[TimeOut(0.1)]
+    public function testAllTestsAreRanInAFiber(): void
+    {
+        self::expectOutputString('ab');
+
+        Loop::futureTick(async(static function (): void {
+            echo 'a';
+        }));
+
+        await(sleep(0.01));
+
+        echo 'b';
+    }
+
     public function testAwait(): void
     {
         $value = time();


### PR DESCRIPTION
Since all tests are executed inside a fiber, there is a default timeout of `30` seconds. To lower or raise that timeout
this package comes with a `TimeOut` attribute. It can be set on the class and method level. When set on both the method level it takes priority over the class level.

```php
<?php

declare(strict_types=1);

namespace WyriHaximus\Tests\AsyncTestUtilities;

use React\EventLoop\Loop;
use WyriHaximus\AsyncTestUtilities\AsyncTestCase;
use WyriHaximus\AsyncTestUtilities\TimeOut;

use function React\Async\async;
use function React\Async\await;
use function React\Promise\resolve;
use function React\Promise\Timer\sleep;
use function time;

#[TimeOut(0.3)]
final class AsyncTestCaseTest extends AsyncTestCase
{
    #[TimeOut(1)]
    public function testAllTestsAreRanInAFiber(): void
    {
        self::expectOutputString('ab');

        Loop::futureTick(async(static function (): void {
            echo 'a';
        }));

        await(sleep(1));

        echo 'b';
    }

    public function testExpectCallableExactly(): void
    {
        $callable = $this->expectCallableExactly(3);

        Loop::futureTick($callable);
        Loop::futureTick($callable);
        Loop::futureTick($callable);
    }

    public function testExpectCallableOnce(): void
    {
        Loop::futureTick($this->expectCallableOnce());
    }
}
```
